### PR TITLE
fix: no port on srv conneciton url

### DIFF
--- a/mongo.go
+++ b/mongo.go
@@ -51,6 +51,10 @@ func createConnectionString(config providers.ConfigProvider, resourceName string
 	}
 	protocol := getProtocol(resInfo)
 	dbName := getDBName(resInfo, resourceName)
+
+	if protocol == "mongodb+srv" {
+		return fmt.Sprintf("%s://%s:%s@%s/%s", protocol, resInfo.Credentials["username"], resInfo.Credentials["password"], resInfo.Host, dbName), nil
+	}
 	return fmt.Sprintf("%s://%s:%s@%s:%s/%s", protocol, resInfo.Credentials["username"], resInfo.Credentials["password"], resInfo.Host, resInfo.Port, dbName), nil
 }
 

--- a/mongo_test.go
+++ b/mongo_test.go
@@ -39,6 +39,47 @@ func TestDBName(t *testing.T) {
 	})
 }
 
+func TestCreateConnectionStringProtocolMongodb(t *testing.T) {
+	t.Run("create connection string with mongodb protocol", func(t *testing.T) {
+		resInfo := &providers.ResourceInfo{
+			Host:        "localhost",
+			Port:        "27017",
+			Credentials: map[string]string{"username": "user", "password": "password"},
+		}
+		dbName := "test"
+		expected := "mongodb://user:password@localhost:27017/test"
+
+		config := &ConfigProviderMock{
+			GetResourceInfoFunc: func(resourceType, resourcePort, resourceName string) (*providers.ResourceInfo, error) {
+				return resInfo, nil
+			},
+		}
+		actual, err := createConnectionString(config, dbName)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("create connection string with mongodb+srv protocol", func(t *testing.T) {
+		resInfo := &providers.ResourceInfo{
+			Host:        "localhost",
+			Port:        "27017",
+			Options:     map[string]interface{}{"protocol": "mongodb+srv"},
+			Credentials: map[string]string{"username": "user", "password": "password"},
+		}
+		dbName := "test"
+		expected := "mongodb+srv://user:password@localhost/test"
+
+		config := &ConfigProviderMock{
+			GetResourceInfoFunc: func(resourceType, resourcePort, resourceName string) (*providers.ResourceInfo, error) {
+				return resInfo, nil
+			},
+		}
+		actual, err := createConnectionString(config, dbName)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+}
+
 func TestCreateConnectionString(t *testing.T) {
 	t.Run("create connection string", func(t *testing.T) {
 		config := &ConfigProviderMock{


### PR DESCRIPTION
It's not allowed to have a port on a SRV connection URL to MongoDB